### PR TITLE
Installer rewrite, generate install locations only and use that in in…

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -135,22 +135,22 @@ isrecordfilenames(std::string name)
 }
 
 std::filesystem::path
-rootinstallpath(bool rootispurelib)
+rootinstalldir(bool rootispurelib)
 {
     std::string rootinstall = rootispurelib ? "purelib" : "platlib";
-    return installpath(rootinstall);
+    return installdir(rootinstall);
 }
 
 std::filesystem::path
-dotdatainstallpath(std::string keydir)
+dotdatainstalldir(std::string keydir)
 {
     std::string dotdatainstall =
       config::instance()->dotdatakeydir2config(keydir);
-    return installpath(dotdatainstall);
+    return installdir(dotdatainstall);
 }
 
 std::filesystem::path
-installpath(std::string pythondir)
+installdir(std::string pythondir)
 {
     std::filesystem::path thepath = config::instance()->get_value(pythondir);
     return thepath.relative_path();
@@ -234,6 +234,12 @@ onlyalloweddotdatapaths(libzippp::ZipArchive &ar)
     }
 
     return true;
+}
+
+bool
+isscript(libzippp::ZipEntry &entry)
+{
+    return pystring::startswith(entry.getName(), dotdatadir() + "/scripts/");
 }
 
 } // namespace crosswrench

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -15,12 +15,13 @@ bool iswheelfilenamevalid(const std::string &);
 bool minimumdistinfofiles(libzippp::ZipArchive &);
 std::string base64urlsafenopad(std::string);
 bool isrecordfilenames(std::string);
-std::filesystem::path rootinstallpath(bool);
-std::filesystem::path installpath(std::string);
+std::filesystem::path rootinstalldir(bool);
+std::filesystem::path installdir(std::string);
 bool get_cmd_output(std::string &, std::string &, std::string);
 bool wheelhasabsolutepaths(libzippp::ZipArchive &);
 bool onlyalloweddotdatapaths(libzippp::ZipArchive &ar);
-std::filesystem::path dotdatainstallpath(std::string);
+std::filesystem::path dotdatainstalldir(std::string);
+bool isscript(libzippp::ZipEntry &);
 } // namespace crosswrench
 
 #endif

--- a/src/record.cpp
+++ b/src/record.cpp
@@ -226,7 +226,7 @@ record::write(bool rootispurelib, std::filesystem::path destdir)
 {
     std::ofstream out;
     std::filesystem::path filename = destdir;
-    filename /= rootinstallpath(rootispurelib);
+    filename /= rootinstalldir(rootispurelib);
     filename /= dotdistinfodir();
     filename /= "RECORD";
     out.open(filename, std::ios_base::binary | std::ios_base::out);

--- a/src/spread.hpp
+++ b/src/spread.hpp
@@ -20,12 +20,11 @@ class spread
 
   private:
     void compile();
-    void installdotdatadir(libzippp::ZipEntry &);
-    void installentry(libzippp::ZipEntry &);
-    void installfile(libzippp::ZipEntry &,
-                     std::filesystem::path,
-                     std::filesystem::path,
-                     bool = false);
+    std::filesystem::path createinstallpath(std::filesystem::path,
+                                            std::filesystem::path);
+    std::filesystem::path dotdatadirinstallpath(libzippp::ZipEntry &);
+    std::filesystem::path installpath(libzippp::ZipEntry &);
+    void installfile(libzippp::ZipEntry &, std::filesystem::path);
     uintptr_t writereplacedpython(const void *,
                                   libzippp_uint64,
                                   std::unique_ptr<Botan::HashFunction> &,


### PR DESCRIPTION
…stallfile

Installer rewrite, generate install locations only and use that in installfile.
Instead of having install methods that generate install prefixes then
calls installfile with this prefix, make them methods that return the whole
install path and make installfile take the installpath as an argument.
Rename the methods accordingly.
The idea behind this is that control functions can later be written to check
that all entries in the wheel can be installed before actually touching
the filesystem, install location generation must be independent from file
writing for this to work.
Since the path generating method have been renamed to the same names as
some functions in functions.cpp, change the name of the functions and change
lines where they are called.
Use a function that takes a ZipEntry to check if a ZipEntry is a script
instead of using a bool to installfile.