### PR TITLE
Use boost::filesystem and C++14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -72,7 +72,7 @@ IncludeCategories:
   - Regex:           '^"'
     Priority:        1
     SortPriority:    0
-  - Regex:           '^<(pystring|pstream|open|lib|cxxopts|csv2|botan)'
+  - Regex:           '^<(pystring|pstream|open|lib|cxxopts|csv2|botan|boost)'
     Priority:        2
     SortPriority:    0
   - Regex:           '<sys\/types\.h>'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(crosswrench
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(CrossWrench)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -45,6 +45,9 @@ cw_add_compile_flag(cw_all_targets INTERFACE -Wextra)
 
 # libs
 option(EXTERNAL_LIBS "Use external libs by default" OFF)
+find_package(Boost REQUIRED COMPONENTS "filesystem")
+target_link_libraries(cw_all_targets INTERFACE Boost::filesystem)
+target_compile_definitions(cw_all_targets INTERFACE BOOST_FILESYSTEM_VERSION=4)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(botan-2 REQUIRED IMPORTED_TARGET botan-2)
 target_link_libraries(cw_all_targets INTERFACE PkgConfig::botan-2)

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -26,8 +26,9 @@ SOFTWARE.
 #include "spread.hpp"
 #include "wheel.hpp"
 
+#include <boost/filesystem.hpp>
+
 #include <cstdlib>
-#include <filesystem>
 #include <iostream>
 
 namespace crosswrench {
@@ -83,10 +84,10 @@ execute()
     }
 
     try {
-        std::filesystem::create_directories(
+        boost::filesystem::create_directories(
           config::instance()->get_value("destdir"));
     }
-    catch (std::filesystem::filesystem_error &e) {
+    catch (boost::filesystem::filesystem_error &e) {
         std::cerr << "destdir argument invalid: " << e.what() << std::endl;
         return EXIT_FAILURE;
     }
@@ -121,7 +122,7 @@ execute()
         std::cerr << s << std::endl;
         return EXIT_FAILURE;
     }
-    catch (std::filesystem::filesystem_error &e) {
+    catch (boost::filesystem::filesystem_error &e) {
         std::cerr << "crosswrench install: " << e.what() << std::endl;
         return EXIT_FAILURE;
     }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -24,6 +24,7 @@ SOFTWARE.
 
 #include "config.hpp"
 
+#include <boost/filesystem.hpp>
 #include <cxxopts.hpp>
 #include <libzippp.h>
 #include <pstream.h>
@@ -34,7 +35,6 @@ SOFTWARE.
 #include <cctype>
 #include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <map>
 #include <string>
 #include <thread>
@@ -48,7 +48,7 @@ distdashversion()
 {
     std::vector<std::string> result;
     std::string wheelarg = config::instance()->get_value("wheel");
-    std::filesystem::path wheelpath{ wheelarg };
+    boost::filesystem::path wheelpath{ wheelarg };
     std::string wheelname = wheelpath.filename().string();
     pystring::split(wheelname, result, "-");
     result.erase(result.begin() + 2, result.end());
@@ -86,7 +86,7 @@ isbase64urlsafenopad(const std::string &str)
 bool
 iswheelfilenamevalid(const std::string &filepath)
 {
-    std::filesystem::path wheelpath{ filepath };
+    boost::filesystem::path wheelpath{ filepath };
     std::string wheelname = wheelpath.filename().string();
 
     if (!pystring::endswith(wheelname, ".whl")) {
@@ -135,14 +135,14 @@ isrecordfilenames(std::string name)
            (name == dotdistinfodir() + "/RECORD.jws");
 }
 
-std::filesystem::path
+boost::filesystem::path
 rootinstalldir(bool rootispurelib)
 {
     std::string rootinstall = rootispurelib ? "purelib" : "platlib";
     return installdir(rootinstall);
 }
 
-std::filesystem::path
+boost::filesystem::path
 dotdatainstalldir(std::string keydir)
 {
     std::string dotdatainstall =
@@ -150,10 +150,10 @@ dotdatainstalldir(std::string keydir)
     return installdir(dotdatainstall);
 }
 
-std::filesystem::path
+boost::filesystem::path
 installdir(std::string pythondir)
 {
-    std::filesystem::path thepath = config::instance()->get_value(pythondir);
+    boost::filesystem::path thepath = config::instance()->get_value(pythondir);
     return thepath.relative_path();
 }
 
@@ -378,13 +378,13 @@ createscript(std::string &rhs)
 }
 
 void
-setexecperms(std::filesystem::path filepath)
+setexecperms(boost::filesystem::path filepath)
 {
-    std::filesystem::permissions(filepath,
-                                 std::filesystem::perms::owner_exec |
-                                   std::filesystem::perms::group_exec |
-                                   std::filesystem::perms::others_exec,
-                                 std::filesystem::perm_options::add);
+    boost::filesystem::permissions(filepath,
+                                 boost::filesystem::perms::owner_exe |
+                                   boost::filesystem::perms::group_exe |
+                                   boost::filesystem::perms::others_exe |
+                                   boost::filesystem::perms::add_perms);
 }
 
 bool

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -1,11 +1,11 @@
 #if !defined(_SRC_FUNCTIONS_HPP_)
 #define _SRC_FUNCTIONS_HPP_
 
+#include <boost/filesystem.hpp>
 #include <cxxopts.hpp>
 #include <libzippp.h>
 
 #include <map>
-#include <filesystem>
 #include <string>
 
 namespace crosswrench {
@@ -16,12 +16,12 @@ bool iswheelfilenamevalid(const std::string &);
 bool minimumdistinfofiles(libzippp::ZipArchive &);
 std::string base64urlsafenopad(std::string);
 bool isrecordfilenames(std::string);
-std::filesystem::path rootinstalldir(bool);
-std::filesystem::path installdir(std::string);
+boost::filesystem::path rootinstalldir(bool);
+boost::filesystem::path installdir(std::string);
 bool get_cmd_output(std::string &, std::vector<std::string> &, std::string);
 bool wheelhasabsolutepaths(libzippp::ZipArchive &);
 bool onlyalloweddotdatapaths(libzippp::ZipArchive &ar);
-std::filesystem::path dotdatainstalldir(std::string);
+boost::filesystem::path dotdatainstalldir(std::string);
 bool isscript(libzippp::ZipEntry &);
 bool strvec_contains(std::vector<std::string> &, std::string &);
 uint16_t getelf16(uint8_t, const uint8_t *);
@@ -29,7 +29,7 @@ uint32_t getelf32(uint8_t, const uint8_t *);
 bool iselfexec(libzippp::ZipEntry &);
 std::map<std::string, std::string> getentrypointscripts(libzippp::ZipEntry &);
 std::string createscript(std::string &);
-void setexecperms(std::filesystem::path);
+void setexecperms(boost::filesystem::path);
 bool wheelhasdotdotpath(libzippp::ZipArchive &);
 std::string expandhome(std::string);
 int countoptorenv(cxxopts::ParseResult &, std::string);

--- a/src/record.cpp
+++ b/src/record.cpp
@@ -25,6 +25,7 @@ SOFTWARE.
 #include "functions.hpp"
 #include "hashlib2botan.hpp"
 
+#include <boost/filesystem.hpp>
 #include <botan/base64.h>
 #include <botan/hash.h>
 #if defined(EXTERNAL_CSV2)
@@ -37,7 +38,6 @@ SOFTWARE.
 #include <pystring.h>
 
 #include <array>
-#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -222,15 +222,15 @@ record::add(std::string filepath,
 }
 
 void
-record::write(bool rootispurelib, std::filesystem::path destdir)
+record::write(bool rootispurelib, boost::filesystem::path destdir)
 {
     std::ofstream out;
-    std::filesystem::path filename = destdir;
+    boost::filesystem::path filename = destdir;
     filename /= rootinstalldir(rootispurelib);
     filename /= dotdistinfodir();
     filename /= "RECORD";
-    out.open(filename, std::ios_base::binary | std::ios_base::out);
-    csv2::Writer csv_w{ out };
+    out.open(filename.string(), std::ios_base::binary | std::ios_base::out);
+    csv2::Writer<csv2::delimiter<','>> csv_w{ out };
     for (auto r : records) {
         std::array<std::string, 3> content{ r.first,
                                             r.second.at(RHASHTYPE).empty()

--- a/src/record.hpp
+++ b/src/record.hpp
@@ -1,9 +1,9 @@
 #if !defined(_SRC_RECORD_HPP_)
 #define _SRC_RECORD_HPP_
 
+#include <boost/filesystem.hpp>
 #include <libzippp.h>
 
-#include <filesystem>
 #include <map>
 #include <string>
 
@@ -16,7 +16,7 @@ class record
     record(std::string);
     bool verify(libzippp::ZipArchive &);
     bool add(std::string, std::string, std::string, std::string);
-    void write(bool, std::filesystem::path);
+    void write(bool, boost::filesystem::path);
 
   private:
     std::map<std::string, std::array<std::string, 3>> records;

--- a/src/spread.hpp
+++ b/src/spread.hpp
@@ -4,10 +4,10 @@
 #include "hashlib2botan.hpp"
 #include "record.hpp"
 
+#include <boost/filesystem.hpp>
 #include <botan/hash.h>
 #include <libzippp.h>
 
-#include <filesystem>
 #include <set>
 #include <string>
 
@@ -20,16 +20,16 @@ class spread
     void install();
 
   private:
-    void add2record(std::filesystem::path,
+    void add2record(boost::filesystem::path,
                     std::unique_ptr<Botan::HashFunction> &);
     void compile();
-    void createdirs(std::filesystem::path);
-    std::filesystem::path createinstallpath(std::filesystem::path,
-                                            std::filesystem::path);
-    std::filesystem::path dotdatadirinstallpath(libzippp::ZipEntry &);
-    std::filesystem::path installpath(libzippp::ZipEntry &);
-    void installfile(libzippp::ZipEntry &, std::filesystem::path);
-    void installfile(const char *, size_t, std::filesystem::path);
+    void createdirs(boost::filesystem::path);
+    boost::filesystem::path createinstallpath(boost::filesystem::path,
+                                            boost::filesystem::path);
+    boost::filesystem::path dotdatadirinstallpath(libzippp::ZipEntry &);
+    boost::filesystem::path installpath(libzippp::ZipEntry &);
+    void installfile(libzippp::ZipEntry &, boost::filesystem::path);
+    void installfile(const char *, size_t, boost::filesystem::path);
     void installinstallerfile();
     uintptr_t writereplacedpython(const void *,
                                   libzippp_uint64,
@@ -42,9 +42,9 @@ class spread
     libzippp::ZipArchive &wheelfile;
     record record2write;
     bool rootispurelib;
-    std::filesystem::path destdir;
+    boost::filesystem::path destdir;
     std::ios_base::openmode outmode;
-    std::set<std::filesystem::path> py_files;
+    std::set<boost::filesystem::path> py_files;
     hashlib2botan h2b;
     bool verbose;
 };


### PR DESCRIPTION
Use boost::filesystem and C++14 instead of
C++17 and std::filesystem in order to lower
the compiler requirements for crosswrench.
Botan that is used for hashing already uses
boost on some systems so the dependency tree
does not grow very much.